### PR TITLE
Replace fastify-react with fastify-nextjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# fastify-react
+# fastify-nextjs
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-react.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-nextjs.svg)](https://greenkeeper.io/)
 
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)  [![Build Status](https://travis-ci.org/fastify/fastify-react.svg?branch=master)](https://travis-ci.org/fastify/fastify-react)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)  [![Build Status](https://travis-ci.org/fastify/fastify-nextjs.svg?branch=master)](https://travis-ci.org/fastify/fastify-nextjs)
 
 React server side rendering support for Fastify with [Next](https://github.com/zeit/next.js/#custom-server-and-routing) Framework.
 
 ## Install
 ```
-npm i fastify-react next --save
+npm i fastify-nextjs next --save
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ The plugin will expose the api `next` in Fastify that will handle the rendering 
 const fastify = require('fastify')()
 
 fastify
-  .register(require('fastify-react'))
+  .register(require('fastify-nextjs'))
   .after(() => {
     fastify.next('/hello')
   })
@@ -36,7 +36,7 @@ export default () => <div>hello world</div>
 ```
 If you need to pass [custom options](https://github.com/zeit/next.js/#custom-configuration) to `next` just pass them to register as second parameter.
 ```js
-fastify.register(require('fastify-react'), { dev: true })
+fastify.register(require('fastify-nextjs'), { dev: true })
 ```
 
 If you need to handle yourself the render part, just pass a callback to `next`:

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const assert = require('assert')
 const fp = require('fastify-plugin')
 const Next = require('next')
 
-function fastifyReact (fastify, options, next) {
+function fastifyNext (fastify, options, next) {
   const app = Next(Object.assign(
     { dev: process.env.NODE_ENV !== 'production' },
     options
@@ -56,7 +56,7 @@ function fastifyReact (fastify, options, next) {
   }
 }
 
-module.exports = fp(fastifyReact, {
+module.exports = fp(fastifyNext, {
   fastify: '>=1.0.0',
-  name: 'fastify-react'
+  name: 'fastify-nextjs'
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-react",
-  "version": "3.0.0",
+  "name": "fastify-nextjs",
+  "version": "1.0.0",
   "description": "React server side rendering support for Fastify with Next",
   "main": "index.js",
   "engines": {
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fastify/fastify-react.git"
+    "url": "git+https://github.com/fastify/fastify-nextjs.git"
   },
   "keywords": [
     "fastify",
@@ -35,9 +35,9 @@
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/fastify/fastify-react/issues"
+    "url": "https://github.com/fastify/fastify-nextjs/issues"
   },
-  "homepage": "https://github.com/fastify/fastify-react#readme",
+  "homepage": "https://github.com/fastify/fastify-nextjs#readme",
   "peerDependencies": {
     "next": "^7.0.2"
   },


### PR DESCRIPTION
Once name of the repo is changed we should verify travis and greenkeeper.

I also don't have permission to rename the repo so one of the core maintainers need to do it