### PR TITLE
update packages for next.js v9 types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ typings/
 
 # next stuff
 .next
+next-env.d.ts
 
 # npm package-lock.json
 package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 
 node_js:
+  - "13"
+  - "12"
   - "11"
   - "10"
-  - "8"
 
 notifications:
   email:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="next" />
+
 import {
   FastifyReply,
   FastifyRequest,
@@ -6,8 +8,8 @@ import {
   RouteSchema,
 } from 'fastify';
 import { IncomingMessage, Server, ServerResponse } from 'http';
-import { DevServer } from 'next';
-import { UrlLike } from 'next/router';
+import DevServer from 'next/dist/server/next-dev-server';
+import { Router } from 'next/router';
 
 declare module 'fastify' {
   type FastifyNextCallback = (
@@ -27,7 +29,7 @@ declare module 'fastify' {
         | {
             method: HTTPMethod;
             schema: RouteSchema;
-            next: UrlLike;
+            next: Router;
           }
         | FastifyNextCallback,
       handle?: FastifyNextCallback

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const Next = require('next')
 
 function fastifyNext (fastify, options, next) {
   const app = Next(Object.assign({}, options, { dev: process.env.NODE_ENV !== 'production' }))
+  const handleNextRequests = app.getRequestHandler()
 
   app
     .prepare()
@@ -17,7 +18,7 @@ function fastifyNext (fastify, options, next) {
         })
         .after(() => {
           fastify.next('/_next/*',
-            (app, req, reply) => app.handleRequest(req.req, reply.res)
+            (app, req, reply) => handleNextRequests(req.req, reply.res)
               .then(() => {
                 reply.sent = true
               })
@@ -35,10 +36,10 @@ function fastifyNext (fastify, options, next) {
     }
 
     assert(typeof path === 'string', 'path must be a string')
-    if (opts.method) assert(typeof opts.method === 'string', 'options.method must be a string')
-    if (opts.schema) assert(typeof opts.schema === 'object', 'options.schema must be an object')
-    if (opts.next) assert(typeof opts.next === 'object', 'options.next must be an object')
-    if (callback) assert(typeof callback === 'function', 'callback must be a function')
+    if (opts.method) { assert(typeof opts.method === 'string', 'options.method must be a string') }
+    if (opts.schema) { assert(typeof opts.schema === 'object', 'options.schema must be an object') }
+    if (opts.next) { assert(typeof opts.next === 'object', 'options.next must be an object') }
+    if (callback) { assert(typeof callback === 'function', 'callback must be a function') }
 
     const method = opts.method || 'get'
     this[method.toLowerCase()](path, opts, handler)

--- a/package.json
+++ b/package.json
@@ -39,18 +39,19 @@
   },
   "homepage": "https://github.com/fastify/fastify-nextjs#readme",
   "peerDependencies": {
-    "next": "^8.0.0"
+    "next": "^9.0.0"
   },
   "dependencies": {
     "fastify-plugin": "^1.2.1"
   },
   "devDependencies": {
-    "@types/next": "^8.0.1",
     "@types/node": "^12.12.7",
+    "@types/react": "^16.9.19",
+    "@types/react-dom": "^16.9.5",
     "cross-env": "^5.2.0",
     "fastify": "^2.0.0",
-    "next": "^8.0.0",
-    "react": "^16.6.3",
+    "next": "^9.2.1",
+    "react": "^16.12.0",
     "react-dom": "^16.6.3",
     "standard": "^14.0.2",
     "tap": "^12.6.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-nextjs#readme",
   "peerDependencies": {
-    "next": "^9.0.0"
+    "next": "^9.3.1"
   },
   "dependencies": {
     "fastify-plugin": "^1.2.1"
@@ -48,13 +48,13 @@
     "@types/node": "^12.12.7",
     "@types/react": "^16.9.19",
     "@types/react-dom": "^16.9.5",
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "fastify": "^2.0.0",
-    "next": "^9.2.1",
+    "next": "^9.3.1",
     "react": "^16.12.0",
     "react-dom": "^16.6.3",
     "standard": "^14.0.2",
-    "tap": "^12.6.5",
+    "tap": "^14.10.7",
     "typescript": "^3.2.2"
   },
   "greenkeeper": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,33 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmit": true,
     "strict": true,
     "noImplicitAny": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
   },
   "files": [
     "./types.test.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "strict": true,
     "noImplicitAny": true,
+    "esModuleInterop": true
   },
   "files": [
     "./types.test.ts"

--- a/types.test.ts
+++ b/types.test.ts
@@ -1,12 +1,14 @@
-import fastify = require('fastify');
-import fastifyReact = require('./index');
+import fastify from 'fastify';
+import fastifyReact from './index';
 
 const app = fastify();
 
 app.register(fastifyReact).after(() => {
   app.next('/*', (nextApp, req, reply) => {
-    return nextApp.handleRequest(req.req, reply.res).then(() => {
-      reply.sent = true;
-    });
+    return nextApp
+      .getRequestHandler()(req.req, reply.res)
+      .then(() => {
+        reply.sent = true;
+      });
   });
 });


### PR DESCRIPTION
Next.js 9 ships its own types now.
They are not like the @types/next type defs so somethings need to change

I believe I was able to get the right type for DevServer, except now theres an error calling `handleRequest` 

```
types.test.ts:8:20 - error TS2341: Property 'handleRequest' is private and only accessible within class 'Server'.
```

Someone who understands next.js should figure out what change needs to be made here in the test and we can go from there