### PR TITLE
Fixed typedefinition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module 'fastify' {
   > {
     next(
       path: string,
-      opts:
+      opts?:
         | {
             method: HTTPMethod;
             schema: RouteSchema;

--- a/types.test.ts
+++ b/types.test.ts
@@ -4,6 +4,8 @@ import fastifyReact from './index';
 const app = fastify();
 
 app.register(fastifyReact).after(() => {
+  app.next('/a');
+  
   app.next('/*', (nextApp, req, reply) => {
     return nextApp
       .getRequestHandler()(req.req, reply.res)


### PR DESCRIPTION
This is only type definition fix. According to the documentation fastify.next('/hello') the 2nd and 3rd parameters are not required.