### PR TITLE
Use requestHandler of next-server as the default handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,6 @@ declare module 'fastify' {
         | {
             method: HTTPMethods;
             schema: FastifySchema;
-            next: Router;
           }
         | FastifyNextCallback,
       handle?: FastifyNextCallback

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ function fastifyNext (fastify, options, next) {
     assert(typeof path === 'string', 'path must be a string')
     if (opts.method) { assert(typeof opts.method === 'string', 'options.method must be a string') }
     if (opts.schema) { assert(typeof opts.schema === 'object', 'options.schema must be an object') }
-    if (opts.next) { assert(typeof opts.next === 'object', 'options.next must be an object') }
     if (callback) { assert(typeof callback === 'function', 'callback must be a function') }
 
     const method = opts.method || 'get'

--- a/index.js
+++ b/index.js
@@ -17,12 +17,7 @@ function fastifyNext (fastify, options, next) {
           app.close()
         })
         .after(() => {
-          fastify.next('/_next/*',
-            (app, req, reply) => handleNextRequests(req.raw, reply.raw)
-              .then(() => {
-                reply.sent = true
-              })
-          )
+          fastify.next('/_next/*')
         })
       next()
     })
@@ -49,7 +44,7 @@ function fastifyNext (fastify, options, next) {
         return callback(app, req, reply)
       }
 
-      app.render(req.raw, reply.res, path, req.query, opts.next || {})
+      return handleNextRequests(req.raw, reply.raw)
     }
   }
 }

--- a/pages/api/user.js
+++ b/pages/api/user.js
@@ -1,0 +1,5 @@
+export default (req, res) => {
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ name: 'John Doe' }))
+}

--- a/test.js
+++ b/test.js
@@ -236,6 +236,28 @@ test('should serve /_next/* static assets', t => {
   fastify.close()
 })
 
+test('should return a json data on api route', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify
+    .register(require('./index'))
+    .after(() => {
+      fastify.next('/api/*')
+    })
+
+  fastify.inject({
+    url: '/api/user',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['content-type'], 'application/json')
+  })
+
+  fastify.close()
+})
+
 function testNextAsset (t, fastify, url) {
   fastify.inject({ url, method: 'GET' }, (err, res) => {
     t.error(err)

--- a/test.js
+++ b/test.js
@@ -30,6 +30,8 @@ test('should return an html document', t => {
   t.plan(3)
 
   const fastify = Fastify()
+  t.tearDown(() => fastify.close())
+
   fastify
     .register(require('./index'))
     .after(() => {
@@ -44,14 +46,14 @@ test('should return an html document', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
   })
-
-  fastify.close()
 })
 
 test('should support different methods', t => {
   t.plan(3)
 
   const fastify = Fastify()
+  t.tearDown(() => fastify.close())
+
   fastify
     .register(require('./index'))
     .after(() => {
@@ -66,14 +68,14 @@ test('should support different methods', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
   })
-
-  fastify.close()
 })
 
 test('should support a custom handler', t => {
   t.plan(3)
 
   const fastify = Fastify()
+  t.tearDown(() => fastify.close())
+
   fastify
     .register(require('./index'))
     .after(() => {
@@ -90,14 +92,14 @@ test('should support a custom handler', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
   })
-
-  fastify.close()
 })
 
 test('should return 404 on undefined route', t => {
   t.plan(2)
 
   const fastify = Fastify()
+  t.tearDown(() => fastify.close())
+
   fastify
     .register(require('./index'))
     .after(() => {
@@ -111,8 +113,6 @@ test('should return 404 on undefined route', t => {
     t.error(err)
     t.equal(res.statusCode, 404)
   })
-
-  fastify.close()
 })
 
 test('should throw if path is not a string', t => {
@@ -224,6 +224,8 @@ test('should serve /_next/* static assets', t => {
       fastify.next('/hello')
     })
 
+  t.tearDown(() => fastify.close())
+
   const pagePrefix = `/_next/static/${buildId}/pages`
 
   testNextAsset(t, fastify, `${pagePrefix}/hello.js`)
@@ -232,8 +234,6 @@ test('should serve /_next/* static assets', t => {
 
   const commonAssets = manifest.pages['/hello']
   commonAssets.map(suffix => testNextAsset(t, fastify, `/_next/${suffix}`))
-
-  fastify.close()
 })
 
 test('should return a json data on api route', t => {
@@ -246,6 +246,8 @@ test('should return a json data on api route', t => {
       fastify.next('/api/*')
     })
 
+  t.tearDown(() => fastify.close())
+
   fastify.inject({
     url: '/api/user',
     method: 'GET'
@@ -254,8 +256,6 @@ test('should return a json data on api route', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-type'], 'application/json')
   })
-
-  fastify.close()
 })
 
 function testNextAsset (t, fastify, url) {

--- a/test.js
+++ b/test.js
@@ -172,25 +172,6 @@ test('should throw if opts.schema is not an object', t => {
   fastify.close()
 })
 
-test('should throw if opts.next is not an object', t => {
-  t.plan(2)
-
-  const fastify = Fastify()
-  fastify
-    .register(require('./index'))
-    .after(err => {
-      t.error(err)
-      try {
-        fastify.next('/hello', { next: 1 })
-        t.fail()
-      } catch (e) {
-        t.equal(e.message, 'options.next must be an object')
-      }
-    })
-
-  fastify.close()
-})
-
 test('should throw if callback is not a function', t => {
   t.plan(2)
 


### PR DESCRIPTION
- Use requestHandler of next-server as the default handler
- Remove the opts.next check

Closes #58 #89 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
