### PR TITLE
Preserve Fastify response headers set by plugins and hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ function fastifyNext (fastify, options, next) {
     this[method.toLowerCase()](path, opts, handler)
 
     function handler (req, reply) {
+      for (const [headerName, headerValue] of Object.entries(reply.getHeaders())) {
+        reply.raw.setHeader(headerName, headerValue)
+      }
+
       if (callback) {
         return callback(app, req, reply)
       }


### PR DESCRIPTION
Fixes #84 (mostly).

Since Fastify buffers headers internally instead of setting them directly on the raw response, headers set by a plugin or hook using `reply.header()` or `reply.headers()` were discarded after control was passed to Next.js, since Next can only see the headers on the raw response and calls `.end()` directly on the response rather than letting Fastify serve it.

This fixes that issue by explicitly setting all Fastify headers on the raw response before passing control to Next.js or a custom Next.js route handler.

However, it doesn't appear to be possible to solve this problem for headers set via `reply` in a custom Next.js route handler itself if the custom handler calls Next.js's `app.render()` directly. In that scenario, the custom handler will still need to ensure that it sets headers on the raw response.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] (n/a) documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
