### PR TITLE
Moar docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ fastify.next('/hello', (app, req, reply) => {
 })
 ```
 
+If you need to handle POST routes, you can define the HTTP method:
+```js
+fastify.next('/api/*', { method: 'GET' });
+fastify.next('/api/*', { method: 'POST' });
+```
+
 ### under-pressure
 
 The plugin includes [under-pressure](https://github.com/fastify/under-pressure), which can be configured by providing an `underPressure` property to the plugin options. 


### PR DESCRIPTION
I try to implement next-auth in a project where I use fastify-next. For that reason, POST routes to the internal API route are needed. I was not aware that the HTTP methods need to be specified - until I checked the source. So I thought a doc update might be helpful.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
