### PR TITLE
Fix TypeScript declaration of `app` argument in callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,13 +7,12 @@ import {
   FastifySchema,
   HTTPMethods
 } from 'fastify';
-import DevServer from 'next/dist/server/next-dev-server';
 import { NextServer } from 'next/dist/server/next';
 import underPressure from 'under-pressure';
 
 declare module 'fastify' {
   type FastifyNextCallback = (
-    app: DevServer,
+    app: NextServer,
     req: FastifyRequest,
     reply: FastifyReply
   ) => Promise<void>;

--- a/types.test.ts
+++ b/types.test.ts
@@ -12,6 +12,10 @@ app.register(fastifyNext, {
   app.next('/a');
 
   app.next('/*', (nextApp, req, reply) => {
+    if (!nextApp.options) {
+      throw new Error("nextApp hasn't options!")
+    }
+
     return nextApp
       .getRequestHandler()(req.raw, reply.raw)
       .then(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Reason

I use Next.js `app` argument wider than just method `getRequestHandler`, that repeats on both `DevServer` and `NextServer`. But it different objects, and now `DevServer` is mistake. 

For access for real `DevServer` (It would be more correct to say `Server` — ancestor of `DevServer`, which only in development mode) you can use `app.server.*`.

#### Checklist

- [x] run `npm run test`
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
