### PR TITLE
fix `next()` type declaration

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,0 +1,14 @@
+import fastify from 'fastify'
+import fastNext from './index';
+const fastifyApp = fastify();
+
+fastifyApp
+  .register(fastNext)
+  .after(() => {
+    fastifyApp.next('/hello')
+  })
+
+fastifyApp.listen(3000, err => {
+  if (err) throw err
+  console.log('Server listenging on http://localhost:3000')
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module 'fastify' {
   ) => Promise<void>;
 
   interface FastifyInstance {
-    next(
+    next:(
       path: string,
       opts?:
         | {
@@ -26,7 +26,7 @@ declare module 'fastify' {
           }
         | FastifyNextCallback,
       handle?: FastifyNextCallback
-    ): void;
+    )=> void;
   }
 
   interface FastifyReply {


### PR DESCRIPTION
fixes #207 
- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
