### PR TITLE
`noServeAssets` option for disable in-box next assets serving.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ fastify.next('/api/*', { method: 'GET' });
 fastify.next('/api/*', { method: 'POST' });
 ```
 
+### Assets serving
+
+By default plugin handle route `${basePath}/_next/*` and forward to Next.js.
+
+If you have custom preprocessing for `_next/*` requests, you can prevent this this handling with `noServeAssets: true` property for plugin options:
+
+```js
+fastify
+  .register(require('fastify-nextjs'), {
+    noServeAssets: true
+  })
+  .after(() => {
+    fastify.next(`${process.env.BASE_PATH || ''}/_next/*`, (app, req, reply) => {
+      // your code
+      app.getRequestHandler()(req.raw, reply.raw).then(() => {
+        reply.sent = true
+      })
+    })
+  })
+```
+
 ### under-pressure
 
 The plugin includes [under-pressure](https://github.com/fastify/under-pressure), which can be configured by providing an `underPressure` property to the plugin options. 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,8 @@ import {
   HTTPMethods
 } from 'fastify';
 import DevServer from 'next/dist/server/next-dev-server';
+import { NextServer } from 'next/dist/server/next';
+import underPressure from 'under-pressure';
 
 declare module 'fastify' {
   type FastifyNextCallback = (
@@ -34,6 +36,16 @@ declare module 'fastify' {
   }
 }
 
-declare const fastifyNext: FastifyPluginCallback<{ [key: string]: any }>;
+// Infer options type, because not exported from Next.
+type NextServerConstructor = ConstructorParameters<typeof NextServer>[0]
+
+declare namespace fastifyNext {
+  interface FastifyNextOptions extends NextServerConstructor {
+    underPressure?: boolean | underPressure.UnderPressureOptions;
+    noServeAssets?: boolean;
+  }
+}
+
+declare const fastifyNext: FastifyPluginCallback<fastifyNext.FastifyNextOptions>;
 
 export default fastifyNext;

--- a/types.test.ts
+++ b/types.test.ts
@@ -4,7 +4,10 @@ import fastifyNext from './index';
 const app = fastify();
 
 app.register(fastifyNext, {
-  logLevel: "error"
+  logLevel: "error", // option from Fastify.js, RegisterOptions
+  underPressure: false, // option from fastify-nextjs, FastifyNextOptions
+  noServeAssets: false, // option from fastify-nextjs, FastifyNextOptions
+  dev: true, // option from Next.js,
 }).after(() => {
   app.next('/a');
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Proposition
1. Add `noServeAssets` option for disable in-box next assets serving.
2. Fix in-box assets serving when used [basePath](https://nextjs.org/docs/api-reference/next.config.js/basepath).
3. Improved plugin options type definition.
4. Fix options reading (before forwarding to Next, remove `noServeAssets` and `underPressure ` when they are `false`).

### Motivation
I use `fastify-nextjs` for split huge monolithic high-load legacy project with React and Rails. 
I use [basePath](https://nextjs.org/docs/api-reference/next.config.js/basepath) for transition-time (time for moving pages/routes to new Next-app with same code-base) and SEO-comparison tests (compare content for legacy versions of pages with next-pages). 
And in same time i use build without `basePath`, for override transited pages on stages and prod.
1) Now in-box asset serving no work if `basePath` defined.
2) I need control requests to `/_next/*` because not them all is a "assets requests". I need handle SPA-json request to GSP-data (`/_next/data/*/*.json`).

#### Checklist

- [x] run `npm run test`
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
