### PR TITLE
Decorate reply with nextRenderError

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,19 @@ fastify.next('/hello', (app, req, reply) => {
 })
 ```
 
-If you need to render with Next.js from within a custom handler (such as an error handler), use `reply.nextRender`
+If you need to render with Next.js from within a custom handler, use `reply.nextRender`
 
 ```js
 app.setErrorHandler((err, req, reply) => {
-  reply.status(err.statusCode || 500)
-  return reply.nextRender('/_error')
+  return reply.nextRender('/a')
+})
+```
+
+If you need to render a Next.js error page, use `reply.nextRenderError`
+
+```js
+app.setErrorHandler((err, req, reply) => {
+  return reply.status(err.statusCode || 500).nextRenderError(err)
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function fastifyNext (fastify, options, next) {
       fastify
         .decorate('next', route.bind(fastify))
         .decorateReply('nextRender', render)
+        .decorateReply('nextRenderError', renderError)
         .addHook('onClose', function () {
           return app.close()
         })
@@ -98,6 +99,25 @@ function fastifyNext (fastify, options, next) {
     }
 
     await app.render(request.raw, reply.raw, path, request.query)
+
+    reply.sent = true
+  }
+
+  async function renderError (err) {
+    const reply = this
+    const { request } = reply
+
+    // set custom headers as next will finish the request
+    for (const [headerName, headerValue] of Object.entries(reply.getHeaders())) {
+      // Fastify sets content-length to `undefined` for error handlers, which is an invalid value
+      if (headerName === 'content-length' && headerValue === undefined) {
+        continue
+      }
+
+      reply.raw.setHeader(headerName, headerValue)
+    }
+
+    await app.renderError(err, request.raw, reply.raw, request.url, request.query)
 
     reply.sent = true
   }

--- a/pages/_error.jsx
+++ b/pages/_error.jsx
@@ -1,0 +1,1 @@
+export default () => <div>error</div>

--- a/test.js
+++ b/test.js
@@ -543,7 +543,7 @@ test('should let next render error page', async t => {
 
   fastify.setErrorHandler((err, req, reply) => {
     reply.status(err.statusCode || 500)
-    return reply.nextRender('/hello')
+    return reply.nextRenderError(err)
   })
 
   const res = await fastify.inject({
@@ -554,7 +554,7 @@ test('should let next render error page', async t => {
   t.equal(res.statusCode, 500)
   t.equal(res.headers['test-header'], 'hello')
   t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
-  t.match(res.payload, '<div>hello world</div>')
+  t.match(res.payload, '<div>error</div>')
 })
 
 async function testNextAsset (t, fastify, url) {

--- a/test.js
+++ b/test.js
@@ -524,7 +524,66 @@ test('should decorate with next render function', async t => {
   t.equal(res.headers['test-header'], 'hello')
 })
 
-test('should let next render error page', async t => {
+test('should decorate with next render error function', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  await fastify.register(require('./index'))
+
+  fastify.addHook('onRequest', (req, reply, done) => {
+    reply.header('test-header', 'hello')
+    done()
+  })
+
+  fastify.get('/hello', (req, reply) => {
+    return reply.nextRenderError(new Error('Test error message'))
+  })
+
+  const res = await fastify.inject({
+    url: '/hello',
+    method: 'GET'
+  })
+
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['test-header'], 'hello')
+})
+
+test('should let next render any page in fastify error handler', async t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  await fastify.register(require('./index'))
+
+  fastify.addHook('onRequest', (req, reply, done) => {
+    reply.header('test-header', 'hello')
+    done()
+  })
+
+  fastify.get('/hello', (req, reply) => {
+    throw new Error('boom')
+  })
+
+  fastify.setErrorHandler((err, req, reply) => {
+    reply.status(err.statusCode || 500)
+    return reply.nextRender('/hello')
+  })
+
+  const res = await fastify.inject({
+    url: '/hello',
+    method: 'GET'
+  })
+
+  t.equal(res.statusCode, 500)
+  t.equal(res.headers['test-header'], 'hello')
+  t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
+  t.match(res.payload, '<div>hello world</div>')
+})
+
+test('should let next render error page in fastify error handler', async t => {
   t.plan(4)
 
   const fastify = Fastify()


### PR DESCRIPTION
Closes #435 

Proxy to Next.js `app.renderError`.

The source code for `app.renderError` at time of writing can be found here:
- [`app.renderError`](https://github.com/vercel/next.js/blob/dda0afd3a45a50cbcb418903f7a0ab56eae51b33/packages/next/server/base-server.ts#L2336) (public)
- [`app.renderErrorToResponse`](https://github.com/vercel/next.js/blob/dda0afd3a45a50cbcb418903f7a0ab56eae51b33/packages/next/server/base-server.ts#L2369) (private)

This method will render an appropriate error page based on the **response status code** - the pathname does not affect the page rendering.

The page that will be rendered by this method can include:

- `/pages/_error.js`
- `/pages/404.js`
- `/pages/500.js`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
