### PR TITLE
feat(types): Allow shorthand route options in `.next`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,13 @@
 /// <reference types="next" />
 
-import {
-  FastifyReply,
-  FastifyRequest,
+import type {
+  ContextConfigDefault,
   FastifyPluginCallback,
+  FastifyRequest,
   FastifySchema,
   HTTPMethods
 } from 'fastify';
+import type { RouteGenericInterface, RouteShorthandOptions } from 'fastify/types/route';
 import { NextServer } from 'next/dist/server/next';
 import underPressure from 'under-pressure';
 
@@ -17,14 +18,24 @@ declare module 'fastify' {
     reply: FastifyReply
   ) => Promise<void>;
 
-  interface FastifyInstance {
-    next(
+  interface FastifyInstance<RawServer, RawRequest, RawReply> {
+    next<
+      RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+      ContextConfig = ContextConfigDefault,
+      SchemaCompiler = FastifySchema
+    >(
       path: string,
       opts?:
-        | {
-            method: HTTPMethods;
-            schema?: FastifySchema;
-          }
+        | (RouteShorthandOptions<
+            RawServer,
+            RawRequest,
+            RawReply,
+            RouteGeneric,
+            ContextConfig,
+            SchemaCompiler
+          > & {
+            method?: HTTPMethods;
+          })
         | FastifyNextCallback,
       handle?: FastifyNextCallback
     ): void;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,12 @@
 import fastify, { FastifyInstance } from 'fastify';
-import { expectError, expectType } from 'tsd';
 import fastifyNext from './index';
+
+// Declaration merging for custom property injection
+declare module 'http' {
+  interface IncomingMessage {
+    server: FastifyInstance
+  }
+}
 
 const app = fastify();
 
@@ -45,4 +51,11 @@ app
         reply.send('OK');
       }
     );
+
+    app.next('/options-with-hook-injecting-custom-property', {
+      onRequest: (req, _, done) => {
+        req.raw.server = req.server;
+        done();
+      },
+    });
   });


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Edit types to reflect allowed options in `.next()`. Those are the same as `RouteShorthandOptions` with the additional optional method to use.

Add test demoing use of route-local `onRequest` hook for custom property injection.

Fixes #432.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

