### PR TITLE
fix (coverage): remove statements not needed since `fastify@3.22.1`

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,6 @@ function fastifyNext (fastify, options, next) {
 }
 
 module.exports = fp(fastifyNext, {
-  fastify: '>=1.0.0',
+  fastify: '>=3.22.1',
   name: 'fastify-nextjs'
 })

--- a/index.js
+++ b/index.js
@@ -90,12 +90,6 @@ function fastifyNext (fastify, options, next) {
 
     // set custom headers as next will finish the request
     for (const [headerName, headerValue] of Object.entries(reply.getHeaders())) {
-      // Fastify sets content-length to `undefined` for error handlers, which is an invalid value
-      /* istanbul ignore next - this check is not needed since https://github.com/fastify/fastify/pull/3375 */
-      if (headerName === 'content-length' && headerValue === undefined) {
-        continue
-      }
-
       reply.raw.setHeader(headerName, headerValue)
     }
 
@@ -110,12 +104,6 @@ function fastifyNext (fastify, options, next) {
 
     // set custom headers as next will finish the request
     for (const [headerName, headerValue] of Object.entries(reply.getHeaders())) {
-      // Fastify sets content-length to `undefined` for error handlers, which is an invalid value
-      /* istanbul ignore next - this check is not needed since https://github.com/fastify/fastify/pull/3375 */
-      if (headerName === 'content-length' && headerValue === undefined) {
-        continue
-      }
-
       reply.raw.setHeader(headerName, headerValue)
     }
 

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ function fastifyNext (fastify, options, next) {
     // set custom headers as next will finish the request
     for (const [headerName, headerValue] of Object.entries(reply.getHeaders())) {
       // Fastify sets content-length to `undefined` for error handlers, which is an invalid value
+      /* istanbul ignore next - this check is not needed since https://github.com/fastify/fastify/pull/3375 */
       if (headerName === 'content-length' && headerValue === undefined) {
         continue
       }
@@ -110,6 +111,7 @@ function fastifyNext (fastify, options, next) {
     // set custom headers as next will finish the request
     for (const [headerName, headerValue] of Object.entries(reply.getHeaders())) {
       // Fastify sets content-length to `undefined` for error handlers, which is an invalid value
+      /* istanbul ignore next - this check is not needed since https://github.com/fastify/fastify/pull/3375 */
       if (headerName === 'content-length' && headerValue === undefined) {
         continue
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,22 +10,22 @@
       "license": "MIT",
       "dependencies": {
         "fastify-plugin": "^3.0.0",
-        "under-pressure": "^5.4.0"
+        "under-pressure": "^5.8.0"
       },
       "devDependencies": {
-        "@types/node": "^17.0.0",
-        "@types/react": "^17.0.0",
-        "@types/react-dom": "^17.0.0",
-        "cross-env": "^7.0.2",
-        "fastify": "^3.6.0",
-        "next": "^12.0.2",
+        "@types/node": "^17.0.10",
+        "@types/react": "^17.0.38",
+        "@types/react-dom": "^17.0.11",
+        "cross-env": "^7.0.3",
+        "fastify": "^3.27.0",
+        "next": "^12.0.8",
         "proxyquire": "^2.1.3",
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
-        "sinon": "^12.0.0",
-        "standard": "^16.0.1",
-        "tap": "^15.0.5",
-        "tsd": "^0.19.0"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "sinon": "^12.0.1",
+        "standard": "^16.0.4",
+        "tap": "^15.1.6",
+        "tsd": "^0.19.1"
       },
       "engines": {
         "node": ">=10"
@@ -3013,9 +3013,9 @@
       "dev": true
     },
     "node_modules/fastify": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.22.0.tgz",
-      "integrity": "sha512-JWNf/S90SOiOp6SwhMFdTT43+jT/gB2Yi2tPHQ/e7Kaua9PzFLm7Qmwhe2jBA3X6HPDKNugrRd7oPYeIb1Q3Zg==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.27.0.tgz",
+      "integrity": "sha512-p99Fd7xt4DFew39U5Wnp/Soy7jkpxpaqToekwQ3XWv+ECUPXd6bSF9l79EiwkutWALtEU/JiRlzS9qjP2gLHFg==",
       "dev": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^1.0.0",
@@ -3023,13 +3023,12 @@
         "avvio": "^7.1.2",
         "fast-json-stringify": "^2.5.2",
         "fastify-error": "^0.3.0",
-        "fastify-warning": "^0.2.0",
-        "find-my-way": "^4.1.0",
+        "find-my-way": "^4.5.0",
         "flatstr": "^1.0.12",
         "light-my-request": "^4.2.0",
         "pino": "^6.13.0",
+        "process-warning": "^1.0.0",
         "proxy-addr": "^2.0.7",
-        "readable-stream": "^3.4.0",
         "rfdc": "^1.1.4",
         "secure-json-parse": "^2.0.0",
         "semver": "^7.3.2",
@@ -3116,9 +3115,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.3.3.tgz",
-      "integrity": "sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.5.1.tgz",
+      "integrity": "sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==",
       "dev": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1",
@@ -5723,6 +5722,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -11829,9 +11834,9 @@
       "dev": true
     },
     "fastify": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.22.0.tgz",
-      "integrity": "sha512-JWNf/S90SOiOp6SwhMFdTT43+jT/gB2Yi2tPHQ/e7Kaua9PzFLm7Qmwhe2jBA3X6HPDKNugrRd7oPYeIb1Q3Zg==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.27.0.tgz",
+      "integrity": "sha512-p99Fd7xt4DFew39U5Wnp/Soy7jkpxpaqToekwQ3XWv+ECUPXd6bSF9l79EiwkutWALtEU/JiRlzS9qjP2gLHFg==",
       "dev": true,
       "requires": {
         "@fastify/ajv-compiler": "^1.0.0",
@@ -11839,13 +11844,12 @@
         "avvio": "^7.1.2",
         "fast-json-stringify": "^2.5.2",
         "fastify-error": "^0.3.0",
-        "fastify-warning": "^0.2.0",
-        "find-my-way": "^4.1.0",
+        "find-my-way": "^4.5.0",
         "flatstr": "^1.0.12",
         "light-my-request": "^4.2.0",
         "pino": "^6.13.0",
+        "process-warning": "^1.0.0",
         "proxy-addr": "^2.0.7",
-        "readable-stream": "^3.4.0",
         "rfdc": "^1.1.4",
         "secure-json-parse": "^2.0.0",
         "semver": "^7.3.2",
@@ -11917,9 +11921,9 @@
       }
     },
     "find-my-way": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.3.3.tgz",
-      "integrity": "sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-4.5.1.tgz",
+      "integrity": "sha512-kE0u7sGoUFbMXcOG/xpkmz4sRLCklERnBcg7Ftuu1iAxsfEt2S46RLJ3Sq7vshsEy2wJT2hZxE58XZK27qa8kg==",
       "dev": true,
       "requires": {
         "fast-decode-uri-component": "^1.0.1",
@@ -13868,6 +13872,12 @@
       "requires": {
         "fromentries": "^1.2.0"
       }
+    },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -46,21 +46,21 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "under-pressure": "^5.4.0"
+    "under-pressure": "^5.8.0"
   },
   "devDependencies": {
-    "@types/node": "^17.0.0",
-    "@types/react": "^17.0.0",
-    "@types/react-dom": "^17.0.0",
-    "cross-env": "^7.0.2",
-    "fastify": "^3.6.0",
-    "next": "^12.0.2",
+    "@types/node": "^17.0.10",
+    "@types/react": "^17.0.38",
+    "@types/react-dom": "^17.0.11",
+    "cross-env": "^7.0.3",
+    "fastify": "^3.27.0",
+    "next": "^12.0.8",
     "proxyquire": "^2.1.3",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "sinon": "^12.0.0",
-    "standard": "^16.0.1",
-    "tap": "^15.0.5",
-    "tsd": "^0.19.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "sinon": "^12.0.1",
+    "standard": "^16.0.4",
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1"
   }
 }


### PR DESCRIPTION
Hello.

This PR aims to :
- remove 2 statements that are not needed since the release of `fastify@3.22.1`
- unlock the upgrade of `fastify` dependency by our GitHub action workflow
- upgrade package dependencies (fix https://github.com/fastify/fastify-nextjs/issues/470)

For reference: 
- the PR that introduced the behavior: https://github.com/fastify/fastify/pull/2546
- the PR that fixed the behavior: https://github.com/fastify/fastify/pull/3375

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
