### PR TITLE
Doc: add known errors section for the plugin timeout error

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ This project is kindly sponsored by:
 - [NearForm](https://nearform.com)
 - [LetzDoIt](https://www.letzdoitapp.com/)
 
+## Known Errors
+### Plugin Timeout
+The default timeout for plugins in Fastify is 10000ms, which can be a problem for huge Next.js Projects where the initial build time is higher than that.
+Usually, you will get an error like this:
+```
+Error: ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: /app/node_modules/fastify-nextjs/index.js. You may have forgotten to call 'done' function or to resolve a Promise
+```
+
+The workaround or fix is to increase the plugin timeout:
+```js
+const isDev = process.env.NODE_ENV !== 'production';
+const fastify = Fastify({ pluginTimeout: isDev ? 120_000 : undefined });
+```
+
 ## License
 
 Licensed under [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -166,15 +166,6 @@ export const getServerSideProps = async function (ctx) {
 };
 ```
 
-## Development
-CI currently runs npm@6 so when upgrading packages, please use this version.
-
-## Acknowledgements
-
-This project is kindly sponsored by:
-- [NearForm](https://nearform.com)
-- [LetzDoIt](https://www.letzdoitapp.com/)
-
 ## Plugin Timeout and Next.js development mode
 The default timeout for plugins in Fastify is 10000ms, which can be a problem for huge Next.js Projects where the initial build time is higher than that.
 Usually, you will get an error like this:
@@ -187,6 +178,15 @@ The workaround or fix is to increase the plugin timeout:
 const isDev = process.env.NODE_ENV !== 'production';
 const fastify = Fastify({ pluginTimeout: isDev ? 120_000 : undefined });
 ```
+
+## Development
+CI currently runs npm@6 so when upgrading packages, please use this version.
+
+## Acknowledgements
+
+This project is kindly sponsored by:
+- [NearForm](https://nearform.com)
+- [LetzDoIt](https://www.letzdoitapp.com/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@ This project is kindly sponsored by:
 - [NearForm](https://nearform.com)
 - [LetzDoIt](https://www.letzdoitapp.com/)
 
-## Known Errors
-### Plugin Timeout
+## Plugin Timeout and Next.js development mode
 The default timeout for plugins in Fastify is 10000ms, which can be a problem for huge Next.js Projects where the initial build time is higher than that.
 Usually, you will get an error like this:
 ```


### PR DESCRIPTION
Hi,

I added the Known Errors Section as discussed here: https://github.com/fastify/fastify-nextjs/issues/464

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
