### PR TITLE
Revert "chore(package): explicitly declare js module type"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "10.0.1",
   "description": "React server side rendering support for Fastify with Next",
   "main": "index.js",
-  "type": "commonjs",
   "types": "types/index.d.ts",
   "standard": {
     "ignore": [


### PR DESCRIPTION
Reverts fastify/fastify-nextjs#862

If we remove this, then CI will pass and also dependabot PRs should run through.