### PR TITLE
chore(package.json): fix delvedor's personal url

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "side",
     "rendering"
   ],
-  "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
+  "author": "Tomas Della Vedova - @delvedor (https://delvedor.dev)",
   "contributors": [
     "Simone Busoli <simone.busoli@nearform.com>"
   ],


### PR DESCRIPTION
Old link no longer exists